### PR TITLE
Specify --test-threads=1 when running test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --verbose -- --test-threads=1


### PR DESCRIPTION
As the test manages environment variables which are not thread-safe.